### PR TITLE
Adding TransactionDetails Table and some fixes

### DIFF
--- a/Database/Tables and views/Create Books.sql
+++ b/Database/Tables and views/Create Books.sql
@@ -3,6 +3,7 @@ CREATE TABLE [Books]
     [ISBN] TEXT NOT NULL,
     [Title] TEXT NOT NULL,
     [Author] TEXT,
+    [Edition] INTEGER,
     [Genre] TEXT,
     [Description] TEXT,
     [Original_language_ID] TEXT,

--- a/Database/Tables and views/Create Discounts.sql
+++ b/Database/Tables and views/Create Discounts.sql
@@ -1,8 +1,9 @@
 CREATE TABLE [Discounts]
 (
     [Discount_ID] INTEGER NOT NULL,
-    [Start_date] TEXT,
-    [End_date] TEXT,
+    [ISBN] TEXT NOT NULL,
+    [Start_date] DATE,
+    [End_date] DATE,
     [Discount_pct] REAL,
     CONSTRAINT [PK_Discounts] PRIMARY KEY ([Discount_ID])
 );

--- a/Database/Tables and views/Create Reviews.sql
+++ b/Database/Tables and views/Create Reviews.sql
@@ -3,6 +3,7 @@ CREATE TABLE [Reviews]
     [ISBN] TEXT NOT NULL,
     [User_ID] INTEGER NOT NULL,
     [Review] TEXT,
+    CONSTRAINT [PK_Reviews] PRIMARY KEY ([ISBN], [User_ID]),
     FOREIGN KEY ([ISBN]) REFERENCES [Books] ([ISBN]),
     FOREIGN KEY ([User_ID]) REFERENCES [Users] ([User_ID])
 );

--- a/Database/Tables and views/Create TransactionDetails.sql
+++ b/Database/Tables and views/Create TransactionDetails.sql
@@ -1,0 +1,10 @@
+CREATE TABLE [TransactionDetails]
+(
+    [Sale_detail_ID] INTEGER NOT NULL,
+    [Sale_ID] INTEGER NOT NULL,
+    [ISBN] TEXT NOT NULL,
+    [Number_of_items] INTEGER NOT NULL,
+    CONSTRAINT [PK_TransactionDetails] PRIMARY KEY ([Sale_detail_ID]),
+    FOREIGN KEY ([Sale_ID]) REFERENCES [Transactions] ([Sale_ID]),
+    FOREIGN KEY ([ISBN]) REFERENCES [Books] ([ISBN])
+);

--- a/Database/Tables and views/Create Transactions.sql
+++ b/Database/Tables and views/Create Transactions.sql
@@ -1,7 +1,7 @@
 CREATE TABLE [Transactions]
 (
     [Sale_ID] INTEGER NOT NULL,
-    [Transaction_date] TEXT NOT NULL,
+    [Transaction_date] DATE NOT NULL,
     [User_ID] TEXT NOT NULL,
     CONSTRAINT [PK_Transactions] PRIMARY KEY ([Sale_ID]),
     FOREIGN KEY ([User_ID]) REFERENCES [Users] ([User_ID])

--- a/Database/Tables and views/Create Users.sql
+++ b/Database/Tables and views/Create Users.sql
@@ -7,5 +7,5 @@ CREATE TABLE [Users]
     [City] TEXT,
     [Zip_code] TEXT,
     [Country] TEXT,
-    CONSTRAINT [PK_Users] PRIMARY KEY ([User_ID])
+    CONSTRAINT [PK_Users] PRIMARY KEY ([User_ID], [Email])
 );


### PR DESCRIPTION
Adding a Transaction details to know which books and how many units of them were added in the transaction. As well as making some fixes into the tables, specially allowing just one wreview of a book per user (having the chance to update it).